### PR TITLE
Discover as much as possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "atty"
@@ -30,15 +30,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -97,27 +97,27 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -138,15 +138,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "num-integer"
@@ -165,6 +165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "os-release"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -199,39 +208,39 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -240,9 +249,18 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "smartos-lx-img-builder"
@@ -251,11 +269,13 @@ dependencies = [
  "anyhow",
  "chrono",
  "libc",
+ "os-release",
  "serde_json",
  "sha1",
  "structopt",
  "url",
  "uuid",
+ "zonename",
 ]
 
 [[package]]
@@ -266,9 +286,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -277,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -290,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.61"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -321,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -336,45 +356,42 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -400,9 +417,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -431,3 +448,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zonename"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbae92f4d6548e85a594164dfb54fcb36a9e32b923dcd43a9fc4dfbd667efb1c"
+dependencies = [
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "smartos-lx-img-builder"
 version = "0.1.0"
-authors = ["Mike Zeller <mike@mikezeller.net>"]
+authors = [
+   "Mike Zeller <mike@mikezeller.net>",
+   "Brian Bennett <brian.bennett@joyent.com>"
+]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,8 +13,10 @@ edition = "2018"
 anyhow = "1.0.38"
 chrono = "0.4.19"
 libc = "0.2.87"
+os-release = "0.1.0"
 serde_json = "1.0.64"
 sha1 = "0.6.0"
 structopt = "0.3.21"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = [ "serde", "v4" ] }
+zonename = "0.1.1"

--- a/guest/lib/smartdc/joyent_rc.local
+++ b/guest/lib/smartdc/joyent_rc.local
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 Joyent, Inc.
+# Copyright 2022 Joyent, Inc.
 #
 
 LOG='/var/log/triton.log'

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,6 +1,6 @@
 use crate::manifest::Manifest;
 use anyhow::{bail, Context, Result};
-use std::fs::OpenOptions;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -122,7 +122,7 @@ pub fn install_tar<P: AsRef<Path>, T: AsRef<Path>>(zroot: P, file: T) -> Result<
     Ok(())
 }
 
-pub fn modify_image<P: AsRef<Path>>(zroot: P) -> Result<()> {
+pub fn modify_image<P: AsRef<Path>>(zroot: P, product: &str, motd: &str) -> Result<()> {
     let zroot = zroot.as_ref();
 
     // XXX these probably are not needed but historically they have been created
@@ -137,17 +137,38 @@ pub fn modify_image<P: AsRef<Path>>(zroot: P) -> Result<()> {
         "native/var",
     ];
 
+    /*
+     * If the tar was created from a docker image, this file might still be
+     * around.
+     */
+    let unwanted_files = [".dockerenv"];
+
     for p in &paths {
         let to_create = zroot.join(p);
         mkdirp(&to_create, 0, 0, 0o755)?;
     }
 
+    for p in &unwanted_files {
+        let file = zroot.join(p);
+        if file.exists() {
+            fs::remove_file(&file)
+                .with_context(|| format!("failed to unlink {}", &file.display()))?;
+            println!("unlinked {}", &file.display());
+        }
+    }
+
     let native_tmp = zroot.join("native/tmp");
     change_perms(&native_tmp, 0, 0, 0o1777)?;
 
-    let fstab = zroot.join("etc/fstab");
-    let contents = include_str!("../files/fstab");
-    create_file_contents(&fstab, contents)?;
+    let fstab_path = zroot.join("etc/fstab");
+    let fstab = include_str!("../files/fstab");
+    create_file_contents(&fstab_path, &fstab)?;
+
+    let product_path = zroot.join("etc/product");
+    create_file_contents(&product_path, &product)?;
+
+    let motd_path = zroot.join("etc/motd");
+    create_file_contents(&motd_path, &motd)?;
 
     Ok(())
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2022 Joyent, Inc.
+ */
+
 use crate::manifest::Manifest;
 use anyhow::{bail, Context, Result};
 use std::fs::{self, OpenOptions};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2022 Joyent, Inc.
+ */
+
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Opts {
         long = "kernel",
         short = "k",
         help = "the kernel version",
-        required = true
+        default_value = "5.10.0"
     )]
     pub kernel: String,
     #[structopt(
@@ -23,23 +23,15 @@ pub struct Opts {
         long = "min",
         short = "m",
         help = "the minimum platform required for the image",
-        required = true
+        default_value = "20210826T002459Z"
     )]
     pub min_platform: String,
-    #[structopt(
-        name = "name",
-        long = "name",
-        short = "n",
-        help = "the name of the image as it would appear in the manifest",
-        required = true
-    )]
-    pub name: String,
     #[structopt(
         name = "description",
         long = "description",
         short = "d",
-        help = "the description of the image as it would appear in the manifest",
-        required = true
+        help = "text to append to the description of the image as it would appear in the manifest",
+        default_value = ""
     )]
     pub description: String,
     #[structopt(
@@ -47,7 +39,7 @@ pub struct Opts {
         long = "url",
         short = "u",
         help = "the url to information about the image as it would appear in the manifest",
-        required = true
+        default_value = "https://docs.joyent.com/public-cloud/instances/infrastructure/images"
     )]
     pub url: String,
     #[structopt(
@@ -55,7 +47,7 @@ pub struct Opts {
         long = "zfs-parent",
         short = "z",
         help = "the parent zfs dataset to use when creating our temporary image",
-        required = true
+        default_value = ""
     )]
     pub zfs_parent: String,
 }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2022 Joyent, Inc.
+ */
+
 use anyhow::{bail, Context, Result};
 use std::fs;
 use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
+extern crate os_release;
+
 use anyhow::Result;
 use chrono::prelude::*;
+use os_release::OsRelease;
+use std::io;
+use std::path::Path;
 use uuid::Uuid;
 
 mod actions;
@@ -23,30 +28,84 @@ macro_rules! run_action {
     }};
 }
 
+fn read_os_release<P: AsRef<Path>>(zroot: P) -> io::Result<OsRelease> {
+    let zroot = zroot.as_ref();
+    let path = &zroot.join("etc/os-release");
+    let release = OsRelease::new_from(path)?;
+    Ok(release)
+}
+
+fn get_zfs_parent(s: &str) -> String {
+    let zonename = zonename::getzonename().expect("failed to get zonename");
+    if s == "" {
+        if zonename == "global" {
+            return "zones".to_string();
+        } else {
+            return format!("zones/{}/data", &zonename);
+        }
+    } else {
+        return s.to_string();
+    }
+}
+
 fn main() -> Result<()> {
     let opts = cli::get_opts();
-
     let utc: DateTime<Utc> = Utc::now();
     let build_date = utc.format("%Y%m%d").to_string();
-    let iuuid = format!("{}-{}", &opts.name, &build_date);
-    let dataset = format!("{}/{}", &opts.zfs_parent, &iuuid);
-    let zfs_tar = format!("{}.zfs.gz", &iuuid);
-    let image_manifest = &format!("{}.json", &iuuid);
+    let uuid = Uuid::new_v4();
+    let iuuid = format!("{}-{}", &uuid, &build_date);
+    let zfs_parent = get_zfs_parent(&opts.zfs_parent);
+
+    let dataset = format!("{}/{}", &zfs_parent, &iuuid);
+    let zroot = create_dataset(&dataset)?;
+    run_action!(install_tar(&zroot, &opts.tar), &dataset);
+
+    let os_release = read_os_release(&zroot).unwrap();
+    let name = format!("{}-{}", os_release.id, os_release.version_id)
+        .trim_end_matches("-")
+        .to_string();
+    let zfs_tar = format!("{}-{}.zfs.gz", &name, &build_date);
+    let image_manifest = &format!("{}-{}.json", &name, &build_date);
+
+    let desc = format!(
+        "Container-native {} 64-bit image. {}",
+        os_release.pretty_name, &opts.description
+    );
     let manifest = Manifest {
-        name: &opts.name,
+        name: &name,
         version: &build_date,
-        description: &opts.description,
+        description: &desc.trim(),
         homepage: &opts.url,
         min_platform: &opts.min_platform,
-        uuid: &Uuid::new_v4(),
+        uuid: &uuid,
         os: "linux",
         kernel: &opts.kernel,
         tar_file: &zfs_tar,
     };
+    let product = [
+        "Name: Joyent Instance".to_string(),
+        format!("Image: {} {}", &os_release.pretty_name, &build_date).to_string(),
+        format!("Documentation: {}", &opts.url).to_string(),
+        format!("Description: {}\n", &desc).to_string(),
+    ]
+    .join("\n");
 
-    let zroot = create_dataset(&dataset)?;
-    run_action!(install_tar(&zroot, &opts.tar), &dataset);
-    run_action!(modify_image(&zroot), &dataset);
+    let motd = [
+        "   __        .                   .".to_string(),
+        " _|  |_      | .-. .  . .-. :--. |-".to_string(),
+        "|_    _|     ;|   ||  |(.-' |  | |".to_string(),
+        "  |__|   `--'  `-' `;-| `-' '  ' `-'".to_string(),
+        format!(
+            "                   /  ;  Instance ({} {})",
+            &os_release.pretty_name, &build_date
+        )
+        .to_string(),
+        format!("                   `-'   {}", &opts.url).to_string(),
+        "\n".to_string(),
+    ]
+    .join("\n");
+
+    run_action!(modify_image(&zroot, &product, &motd), &dataset);
     run_action!(install_guest_tools(&zroot), &dataset);
     run_action!(create_dataset_gzip(&dataset, &zfs_tar), &dataset);
     run_action!(create_manifest(manifest, &image_manifest), &dataset);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2022 Joyent, Inc.
+ */
+
 extern crate os_release;
 
 use anyhow::{Context, Result};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2022 Joyent, Inc.
+ */
+
 use anyhow::Result;
 use chrono::prelude::*;
 use sha1::Sha1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2022 Joyent, Inc.
+ */
+
 use anyhow::{bail, Context, Result};
 use std::ffi::CString;
 use std::fs;


### PR DESCRIPTION
This will derive most properties from the extracted tar (from `etc/os-release`) or fabricate somewhat-sane defaults.

```
~/smartos-lx-img-builder]# cargo run -- -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/smartos-lx-img-builder -h`
smartos-lx-img-builder 0.1.0

USAGE:
    smartos-lx-img-builder [OPTIONS] --tar <tar>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -d, --description <description>    text to append to the description of the image as it would appear in the manifest
                                       [default: ]
    -k, --kernel <kernel>              the kernel version [default: 5.10.0]
    -m, --min <min_platform>           the minimum platform required for the image [default: 20210826T002459Z]
    -t, --tar <tar>                    lx userland tar file
    -u, --url <url>                    the url to information about the image as it would appear in the manifest
                                       [default: https://docs.joyent.com/public-cloud/instances/infrastructure/images]
    -z, --zfs-parent <zfs_parent>      the parent zfs dataset to use when creating our temporary image [default: ]
```